### PR TITLE
CI Pipeline for publishing docker image to dockerhub  #181

### DIFF
--- a/.github/workflows/Docker-Publish.yml
+++ b/.github/workflows/Docker-Publish.yml
@@ -1,5 +1,6 @@
 # simple workflow implementing a CI pipeline to build docker image and push it to hub.docker.com
 name: Docker Image Build and Push CI
+
 # run the workflow on each push/pull request to the main branch 
 on:
   push:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,26 @@
+# simple workflow implementing a CI pipeline to build docker image and push it to hub.docker.com
+name: Docker Image Build and Push CI
+# run the workflow on each push/pull request to the main branch 
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    # login to dockerhub using the credentials from the repo secrets 
+    - name: Login to docker-hub
+      run:  docker login --username=${{ secrets.DOCKER_USERNAME }} --password=${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    # build the docker image and tag it
+    - name: Build docker-image
+      run: docker build -t ${{ secrets.DOCKER_USERNAME }}/rest-fetch:latest .
+    # push the image to docker hub
+    - name: Push to registry
+      run: docker push ${{ secrets.DOCKER_USERNAME }}/rest-fetch:latest


### PR DESCRIPTION
# Related Issue

-   Built the CI pipeline for publishing docker image to docker hub mentioned in the issue #181
- 
 ## Note

 - make sure the dockerhub credentials are added to the secrets with these names
 username : DOCKER_USERNAME
 access token : DOCKER_HUB_ACCESS_TOKEN